### PR TITLE
Fix NLTK Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Hangouts.json

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run:
 
 <b>Step 6.</b>
 
-Download the sentiment training file found here -> https://drive.google.com/file/d/0B4iRo-F4K4f8VXFhd2pLWUJTdTg/view?usp=sharing and place it in the directory containing the code. See http://help.sentiment140.com/for-students/ for details.
+Download the sentiment training file found here -> https://drive.google.com/file/d/0B4iRo-F4K4f8VXFhd2pLWUJTdTg/view?usp=sharing and place it in the directory containing the code with the filename `sentiment_training.txt`. See http://help.sentiment140.com/for-students/ for details.
 
 <b>Step 7.</b>
 

--- a/sender_analysis.py
+++ b/sender_analysis.py
@@ -11,7 +11,7 @@ import random
 
 from nltk.classify import NaiveBayesClassifier
 from sklearn.metrics import classification_report
-
+from nltk.metrics.confusionmatrix import ConfusionMatrix
 
 def word_feats(words):
     return dict([(word, True) for word in words])
@@ -99,7 +99,7 @@ def run_sender_classifier(sender_features, get_sender_probs = True, check_sender
         pred[prediction].add(i)
         preds.append(prediction)
     
-    cm = nltk.metrics.ConfusionMatrix(gold, preds)
+    cm = ConfusionMatrix(gold, preds)
     print(cm.pretty_format(sort_by_count = True, show_percents = True, truncate = 9))
     print(classification_report(y_true = gold, y_pred = preds))
     print("train on {0} instances, test on {1} instances".format(len(train_features), len(test_features)))
@@ -214,7 +214,7 @@ def go_check_sender_convergence(classifier, number_of_phases = 5):
             pred[prediction].add(i)
             preds.append(prediction)
         
-        cm = nltk.metrics.ConfusionMatrix(gold, preds)
+        cm = ConfusionMatrix(gold, preds)
         print(cm.pretty_format(sort_by_count = True, show_percents = True, truncate = 9))
         print(classification_report(y_true = gold, y_pred = preds))
         print("train on {0} instances, test on {1} instances".format(len(train_features), len(test_features)))


### PR DESCRIPTION
- Add .gitignore with Hangouts.json
- fix NLTK bug: https://github.com/airalcorn2/Hangouts-NLP/issues/1
- specify filename of `sentiment_training.txt` in README (filename when clicking the download link is `sentimentTraining`, but the script is looking for `sentiment_training.txt` )
